### PR TITLE
Fix hypothesis icon import and trade preview math

### DIFF
--- a/src/components/AddTradeBottomSheet.tsx
+++ b/src/components/AddTradeBottomSheet.tsx
@@ -77,10 +77,10 @@ export function AddTradeBottomSheet({ isOpen, onClose }: AddTradeBottomSheetProp
   const exitNum = parseFloat(exitPrice) || 0;
   
   const stopDistance = Math.abs(entryNum - stopNum);
-  const rMultiple = stopDistance > 0 && exitNum > 0 ? 
-    Math.abs(exitNum - entryNum) / stopDistance * (direction === 'long' ? 1 : -1) : 0;
-  const pnl = entryNum > 0 && exitNum > 0 ? 
-    (direction === 'long' ? exitNum - entryNum : entryNum - exitNum) / entryNum * riskAmount : 0;
+  const directionalDiff = direction === 'long' ? exitNum - entryNum : entryNum - exitNum;
+  const rMultiple = stopDistance > 0 && exitNum > 0 ? directionalDiff / stopDistance : 0;
+  const pnl = entryNum > 0 && exitNum > 0 ?
+    directionalDiff / entryNum * riskAmount : 0;
 
   // Check if form is valid
   const isFormValid = entryPrice && stopLoss && asset && locations.length > 0 && aggression.length > 0;

--- a/src/components/HypothesisMode.tsx
+++ b/src/components/HypothesisMode.tsx
@@ -7,11 +7,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { 
-  Beaker, 
-  Plus, 
-  TrendingUp, 
-  TrendingDown, 
+import {
+  Flask,
+  Plus,
+  TrendingUp,
+  TrendingDown,
   BarChart3,
   CheckCircle,
   PauseCircle,
@@ -368,7 +368,7 @@ export function HypothesisMode() {
       {hypotheses.length === 0 && (
         <Card className="bg-trading-card border-trading-border">
           <CardContent className="text-center py-12">
-            <Beaker className="h-12 w-12 text-trading-muted mx-auto mb-4" />
+            <Flask className="h-12 w-12 text-trading-muted mx-auto mb-4" />
             <h3 className="text-lg font-semibold text-foreground mb-2">No Hypotheses Yet</h3>
             <p className="text-trading-muted mb-4">
               Create your first hypothesis to start forward testing new strategies


### PR DESCRIPTION
## Summary
- import the Flask icon used throughout HypothesisMode so the component renders without crashing
- correct the R-multiple and PnL preview formulas so short trades display positive values when profitable

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b7159fb88323a703a1aae271969d