### PR TITLE
Add bias quiz workflow and execution guardrails

### DIFF
--- a/src/components/BiasQuizModal.tsx
+++ b/src/components/BiasQuizModal.tsx
@@ -1,0 +1,384 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import type { BiasQuizResult, BiasConfidence } from '@/types/bias';
+import type { MarketStateValue } from '@/types/bias';
+import { getActiveSession, TRADING_SESSIONS } from '@/lib/tradingSessions';
+
+interface BiasQuizModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onComplete: (result: BiasQuizResult) => Promise<void> | void;
+}
+
+const LOCATION_OPTIONS = [
+  'Outside value & holding beyond edge (σ1→σ2)',
+  'Inside value / reclaimed VAH/VAL',
+  'Just reclaimed VWAP after stretch',
+  'Undecided (skip)'
+] as const;
+
+const ORDER_FLOW_OPTIONS = [
+  'CVD with move',
+  'Footprint imbalances with move',
+  'Absorption/exhaustion against move',
+  'Big prints in trend direction',
+  'None/unclear'
+] as const;
+
+const STRUCTURE_OPTIONS = [
+  'Impulse + shallow PB',
+  'Failed breakout & reclaim',
+  'Range rotation'
+] as const;
+
+const CONFIDENCE_OPTIONS: BiasConfidence[] = ['LOW', 'MEDIUM', 'HIGH'];
+
+type DirectionChoice = 'LONG' | 'SHORT';
+
+interface QuizState {
+  location: typeof LOCATION_OPTIONS[number] | '';
+  orderFlow: string[];
+  structure: typeof STRUCTURE_OPTIONS[number] | '';
+  session: string;
+  direction: DirectionChoice | null;
+  confidence: BiasConfidence | null;
+}
+
+const defaultQuizState = (session: string): QuizState => ({
+  location: '',
+  orderFlow: [],
+  structure: '',
+  session,
+  direction: null,
+  confidence: null
+});
+
+const mapToResult = (state: QuizState): BiasQuizResult => {
+  const outside = state.location.startsWith('Outside value');
+  const insideValue = state.location.startsWith('Inside value');
+  const failedBreakout = state.structure === 'Failed breakout & reclaim';
+  const impulse = state.structure === 'Impulse + shallow PB';
+  const range = state.structure === 'Range rotation';
+  const ofWithMove = state.orderFlow.some(option =>
+    option === 'CVD with move' || option === 'Footprint imbalances with move'
+  );
+  const ofAbsorption = state.orderFlow.includes('Absorption/exhaustion against move');
+  const undecidedEverywhere =
+    state.location === 'Undecided (skip)' &&
+    (state.orderFlow.length === 0 || state.orderFlow.includes('None/unclear')) &&
+    range;
+
+  let marketState: MarketStateValue | null = null;
+
+  if (outside && ofWithMove && impulse && !ofAbsorption) {
+    marketState = 'OUT_OF_BALANCE';
+  } else if (failedBreakout || insideValue || ofAbsorption || range) {
+    marketState = 'IN_BALANCE';
+  }
+
+  let bias: BiasQuizResult['bias'] = 'NONE';
+
+  if (!state.direction || undecidedEverywhere) {
+    marketState = marketState ?? null;
+    bias = 'NONE';
+  } else if (marketState === 'OUT_OF_BALANCE') {
+    bias = state.direction === 'LONG' ? 'OOB_LONG' : 'OOB_SHORT';
+  } else if (marketState === 'IN_BALANCE') {
+    bias = state.direction === 'LONG' ? 'MR_LONG' : 'MR_SHORT';
+  } else {
+    bias = 'NONE';
+  }
+
+  if (bias === 'NONE') {
+    marketState = marketState === 'IN_BALANCE' || marketState === 'OUT_OF_BALANCE' ? marketState : null;
+  }
+
+  const tags = [
+    state.location !== 'Undecided (skip)' ? state.location : null,
+    ...state.orderFlow.filter(option => option !== 'None/unclear'),
+    state.structure,
+    state.session
+  ].filter((item): item is string => Boolean(item));
+
+  return {
+    bias,
+    market_state: bias === 'NONE' ? null : marketState,
+    confidence: state.confidence,
+    tags
+  };
+};
+
+export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalProps) {
+  const { toast } = useToast();
+  const [autoSession, setAutoSession] = useState(() => getActiveSession()?.name ?? 'Unknown session');
+  const [quizState, setQuizState] = useState<QuizState>(() => defaultQuizState(getActiveSession()?.name ?? 'Unknown session'));
+  const [step, setStep] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+
+  const resetState = useCallback((sessionName: string) => {
+    setQuizState(defaultQuizState(sessionName));
+    setStep(0);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      const detectedSession = getActiveSession()?.name ?? autoSession;
+      setAutoSession(detectedSession);
+      resetState(detectedSession);
+    } else {
+      resetState(autoSession);
+    }
+  }, [open, autoSession, resetState]);
+
+  const toggleOrderFlow = (choice: string) => {
+    setQuizState(prev => {
+      const exists = prev.orderFlow.includes(choice);
+      let next = prev.orderFlow.filter(item => item !== choice);
+      if (!exists) {
+        next = [...prev.orderFlow, choice];
+      }
+      if (choice === 'None/unclear') {
+        next = exists ? [] : ['None/unclear'];
+      } else {
+        next = next.filter(item => item !== 'None/unclear');
+      }
+      return { ...prev, orderFlow: next };
+    });
+  };
+
+  const canNext = () => {
+    switch (step) {
+      case 0:
+        return Boolean(quizState.location);
+      case 1:
+        return quizState.orderFlow.length > 0;
+      case 2:
+        return Boolean(quizState.structure);
+      case 3:
+        return Boolean(quizState.direction);
+      default:
+        return true;
+    }
+  };
+
+  const goNext = () => {
+    if (step < 4 && canNext()) {
+      setStep(step + 1);
+    }
+  };
+
+  const goBack = () => {
+    if (step > 0) {
+      setStep(step - 1);
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!canNext()) return;
+    const result = mapToResult(quizState);
+    setSubmitting(true);
+    try {
+      await onComplete(result);
+      onOpenChange(false);
+      resetState();
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Unable to save bias',
+        description: 'Something went wrong while saving your bias. Please try again.',
+        variant: 'destructive'
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const sessionOptions = useMemo(() => {
+    const options = TRADING_SESSIONS.map(session => session.name);
+    if (!options.includes(autoSession)) {
+      options.unshift(autoSession);
+    }
+    return options;
+  }, [autoSession]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg border-trading-border bg-trading-card text-foreground">
+        <DialogHeader>
+          <DialogTitle>Bias Quiz</DialogTitle>
+          <DialogDescription>Five fast taps to lock in your trading context.</DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-4 space-y-6">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.18em] text-slate-400">
+            <span>Step {step + 1} of 5</span>
+            <div className="flex gap-1">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <span
+                  key={index}
+                  className={
+                    index <= step
+                      ? 'h-1.5 w-6 rounded-full bg-indigo-400'
+                      : 'h-1.5 w-6 rounded-full bg-slate-700'
+                  }
+                />
+              ))}
+            </div>
+          </div>
+
+          {step === 0 && (
+            <section>
+              <h3 className="text-base font-semibold text-foreground">Where is price relative to value/VWAP?</h3>
+              <div className="mt-3 grid grid-cols-1 gap-2">
+                {LOCATION_OPTIONS.map(option => (
+                  <Button
+                    key={option}
+                    type="button"
+                    variant={quizState.location === option ? 'default' : 'outline'}
+                    className="justify-start rounded-xl border border-slate-700 bg-slate-900/40 py-6 text-left text-sm"
+                    onClick={() => setQuizState(prev => ({ ...prev, location: option }))}
+                  >
+                    {option}
+                  </Button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {step === 1 && (
+            <section>
+              <h3 className="text-base font-semibold text-foreground">What does order flow say?</h3>
+              <p className="mt-1 text-xs text-slate-400">Tap all that apply.</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {ORDER_FLOW_OPTIONS.map(option => {
+                  const isSelected = quizState.orderFlow.includes(option);
+                  return (
+                    <Badge
+                      key={option}
+                      variant={isSelected ? 'default' : 'outline'}
+                      className="cursor-pointer rounded-full px-4 py-2 text-sm"
+                      onClick={() => toggleOrderFlow(option)}
+                    >
+                      {option}
+                    </Badge>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {step === 2 && (
+            <section className="space-y-4">
+              <div>
+                <h3 className="text-base font-semibold text-foreground">Structure right now?</h3>
+                <div className="mt-3 grid grid-cols-1 gap-2">
+                  {STRUCTURE_OPTIONS.map(option => (
+                    <Button
+                      key={option}
+                      type="button"
+                      variant={quizState.structure === option ? 'default' : 'outline'}
+                      className="justify-start rounded-xl border border-slate-700 bg-slate-900/40 py-5 text-left text-sm"
+                      onClick={() => setQuizState(prev => ({ ...prev, structure: option }))}
+                    >
+                      {option}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Session</h4>
+                <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                  {sessionOptions.map(option => (
+                    <Button
+                      key={option}
+                      type="button"
+                      variant={quizState.session === option ? 'default' : 'outline'}
+                      className="justify-center rounded-xl border border-slate-700 bg-slate-900/40 py-3"
+                      onClick={() => setQuizState(prev => ({ ...prev, session: option }))}
+                    >
+                      {option}
+                    </Button>
+                  ))}
+                  <Button
+                    type="button"
+                    variant={quizState.session === 'Override' ? 'default' : 'outline'}
+                    className="justify-center rounded-xl border border-slate-700 bg-slate-900/40 py-3"
+                    onClick={() => setQuizState(prev => ({ ...prev, session: 'Override' }))}
+                  >
+                    Override
+                  </Button>
+                </div>
+              </div>
+            </section>
+          )}
+
+          {step === 3 && (
+            <section>
+              <h3 className="text-base font-semibold text-foreground">Direction</h3>
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                <Button
+                  type="button"
+                  variant={quizState.direction === 'LONG' ? 'default' : 'outline'}
+                  className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 py-6 text-base"
+                  onClick={() => setQuizState(prev => ({ ...prev, direction: 'LONG' }))}
+                >
+                  Long
+                </Button>
+                <Button
+                  type="button"
+                  variant={quizState.direction === 'SHORT' ? 'default' : 'outline'}
+                  className="rounded-xl border border-rose-500/40 bg-rose-500/10 py-6 text-base"
+                  onClick={() => setQuizState(prev => ({ ...prev, direction: 'SHORT' }))}
+                >
+                  Short
+                </Button>
+              </div>
+            </section>
+          )}
+
+          {step === 4 && (
+            <section>
+              <h3 className="text-base font-semibold text-foreground">Confidence (optional)</h3>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {CONFIDENCE_OPTIONS.map(option => (
+                  <Button
+                    key={option}
+                    type="button"
+                    variant={quizState.confidence === option ? 'default' : 'outline'}
+                    className="rounded-full px-4 py-2 text-sm"
+                    onClick={() =>
+                      setQuizState(prev => ({
+                        ...prev,
+                        confidence: prev.confidence === option ? null : option
+                      }))
+                    }
+                  >
+                    {option.toLowerCase()}
+                  </Button>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+
+        <div className="mt-6 flex items-center justify-between">
+          <Button variant="ghost" onClick={goBack} disabled={step === 0 || submitting}>
+            Back
+          </Button>
+          {step < 4 ? (
+            <Button onClick={goNext} disabled={!canNext()}>
+              Next
+            </Button>
+          ) : (
+            <Button onClick={handleComplete} disabled={submitting || !canNext()}>
+              {submitting ? 'Saving…' : 'Confirm'}
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/BiasStateCard.tsx
+++ b/src/components/BiasStateCard.tsx
@@ -1,0 +1,61 @@
+import { cn } from '@/lib/utils';
+import { biasLabels, biasTone, marketStateLabels, marketStateTone, toneClasses } from '@/types/bias';
+import type { BiasStateSnapshot } from '@/types/bias';
+import { Pencil } from 'lucide-react';
+
+interface BiasStateCardProps {
+  value?: BiasStateSnapshot | null;
+  onEdit: () => void;
+  isCompact?: boolean;
+  loading?: boolean;
+}
+
+const Pill = ({ label, tone }: { label: string; tone: keyof typeof toneClasses }) => (
+  <span
+    className={cn(
+      'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium tracking-tight',
+      toneClasses[tone]
+    )}
+  >
+    {label}
+  </span>
+);
+
+export function BiasStateCard({ value, onEdit, isCompact = false, loading }: BiasStateCardProps) {
+  const showValue = Boolean(value);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between rounded-2xl border border-slate-700/50 bg-slate-900/60 px-4',
+        isCompact ? 'py-3' : 'py-4'
+      )}
+    >
+      <div className="flex flex-1 flex-wrap items-center gap-2">
+        <span className="text-sm font-semibold text-slate-100">Bias &amp; Market State</span>
+        {loading ? (
+          <span className="text-xs text-slate-400">Loading…</span>
+        ) : showValue ? (
+          <>
+            <Pill label={biasLabels[value!.bias]} tone={biasTone[value!.bias]} />
+            {value?.market_state ? (
+              <Pill label={marketStateLabels[value.market_state]} tone={marketStateTone[value.market_state]} />
+            ) : (
+              <Pill label="State: Not set" tone="zinc" />
+            )}
+          </>
+        ) : (
+          <span className="text-xs text-slate-400">Not set</span>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium text-indigo-300 transition hover:bg-indigo-500/10 hover:text-indigo-200"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+        {showValue ? 'Edit' : 'Set bias/state'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/TradeHeatmap.tsx
+++ b/src/components/TradeHeatmap.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { BarChart3, Clock, TrendingUp, TrendingDown, AlertTriangle } from 'lucide-react';
 import type { Database } from '@/integrations/supabase/types';
+import { isMeanReversionModel, isTrendModel } from '@/lib/executionModels';
 
 type Trade = Database['public']['Tables']['trades']['Row'];
 
@@ -63,8 +64,8 @@ export function TradeHeatmap({ trades }: TradeHeatmapProps) {
 
   // Model performance comparison
   const modelStats = {
-    trend: trades.filter(t => t.model === 'trend' && t.status === 'closed'),
-    mean_reversion: trades.filter(t => t.model === 'mean_reversion' && t.status === 'closed')
+    trend: trades.filter(t => t.status === 'closed' && isTrendModel(t.model)),
+    mean_reversion: trades.filter(t => t.status === 'closed' && isMeanReversionModel(t.model))
   };
 
   const modelPerformance = Object.entries(modelStats).map(([model, modelTrades]) => {

--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+import { useAuth } from './useAuth';
+import type { BiasQuizResult, BiasStateSnapshot } from '@/types/bias';
+
+type BiasViewRow = Database['public']['Views']['v_current_bias']['Row'];
+type BiasTableRow = Database['public']['Tables']['bias_state']['Row'];
+
+type BiasStateResponse = BiasStateSnapshot | null;
+
+const mapTags = (value: unknown): string[] | null => {
+  if (!value) return null;
+  if (Array.isArray(value)) {
+    return value.filter((tag): tag is string => typeof tag === 'string');
+  }
+  return null;
+};
+
+const mapRowToSnapshot = (row: BiasViewRow | BiasTableRow): BiasStateSnapshot => ({
+  id: 'id' in row ? row.id : undefined,
+  day_key: 'day_key' in row ? row.day_key : undefined,
+  bias: row.bias,
+  market_state: row.market_state,
+  confidence: row.confidence,
+  tags: mapTags(row.tags ?? null),
+  selected_at: row.selected_at,
+});
+
+export function useBiasState() {
+  const { user } = useAuth();
+  const [biasState, setBiasState] = useState<BiasStateResponse>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const dayKey = useMemo(() => format(new Date(), 'yyyy-MM-dd'), []);
+
+  const fetchCurrent = useCallback(async () => {
+    if (!user) {
+      setBiasState(null);
+      return;
+    }
+
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('v_current_bias')
+      .select('*')
+      .eq('day_key', dayKey)
+      .maybeSingle();
+
+    if (error) {
+      console.error('Error loading bias state', error);
+      setBiasState(null);
+    } else {
+      setBiasState(data ? mapRowToSnapshot(data) : null);
+    }
+
+    setLoading(false);
+  }, [user, dayKey]);
+
+  useEffect(() => {
+    fetchCurrent();
+  }, [fetchCurrent]);
+
+  const saveBiasState = useCallback(
+    async (result: BiasQuizResult) => {
+      if (!user) throw new Error('User not authenticated');
+
+      setSaving(true);
+
+      try {
+        const { error: deactivateError } = await supabase
+          .from('bias_state')
+          .update({ active: false })
+          .eq('day_key', dayKey)
+          .eq('active', true);
+
+        if (deactivateError) {
+          throw deactivateError;
+        }
+
+        const insertPayload: Database['public']['Tables']['bias_state']['Insert'] = {
+          day_key: dayKey,
+          bias: result.bias,
+          market_state: result.market_state ?? null,
+          confidence: result.confidence ?? null,
+          tags: result.tags,
+          selected_by: user.id,
+          active: true,
+        };
+
+        const { data, error } = await supabase
+          .from('bias_state')
+          .insert(insertPayload)
+          .select('*')
+          .single();
+
+        if (error) {
+          throw error;
+        }
+
+        setBiasState(mapRowToSnapshot(data));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [user, dayKey]
+  );
+
+  return {
+    biasState,
+    dayKey,
+    loading,
+    saving,
+    refresh: fetchCurrent,
+    saveBiasState,
+  } as const;
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,42 @@ export type Database = {
   }
   public: {
     Tables: {
+      bias_state: {
+        Row: {
+          active: boolean
+          bias: 'OOB_LONG' | 'OOB_SHORT' | 'MR_LONG' | 'MR_SHORT' | 'NONE'
+          confidence: 'LOW' | 'MEDIUM' | 'HIGH' | null
+          day_key: string
+          id: string
+          market_state: 'OUT_OF_BALANCE' | 'IN_BALANCE' | null
+          selected_at: string
+          selected_by: string | null
+          tags: Json | null
+        }
+        Insert: {
+          active?: boolean
+          bias: 'OOB_LONG' | 'OOB_SHORT' | 'MR_LONG' | 'MR_SHORT' | 'NONE'
+          confidence?: 'LOW' | 'MEDIUM' | 'HIGH' | null
+          day_key: string
+          id?: string
+          market_state?: 'OUT_OF_BALANCE' | 'IN_BALANCE' | null
+          selected_at?: string
+          selected_by?: string | null
+          tags?: Json | null
+        }
+        Update: {
+          active?: boolean
+          bias?: 'OOB_LONG' | 'OOB_SHORT' | 'MR_LONG' | 'MR_SHORT' | 'NONE'
+          confidence?: 'LOW' | 'MEDIUM' | 'HIGH' | null
+          day_key?: string
+          id?: string
+          market_state?: 'OUT_OF_BALANCE' | 'IN_BALANCE' | null
+          selected_at?: string
+          selected_by?: string | null
+          tags?: Json | null
+        }
+        Relationships: []
+      }
       daily_stats: {
         Row: {
           avg_r: number | null
@@ -155,7 +191,10 @@ export type Database = {
       trades: {
         Row: {
           aggression: string[] | null
+          bias_snapshot: Json
           asset: string
+          checklist: Json
+          checklist_complete: boolean
           created_at: string
           direction: string
           duration_minutes: number | null
@@ -177,6 +216,7 @@ export type Database = {
           r_multiple: number | null
           risk_amount: number
           risk_tier: string
+          session: string | null
           scenarios: string[] | null
           screenshot_url: string | null
           status: string | null
@@ -188,6 +228,9 @@ export type Database = {
         Insert: {
           aggression?: string[] | null
           asset: string
+          bias_snapshot: Json
+          checklist: Json
+          checklist_complete?: boolean
           created_at?: string
           direction: string
           duration_minutes?: number | null
@@ -209,6 +252,7 @@ export type Database = {
           r_multiple?: number | null
           risk_amount: number
           risk_tier: string
+          session?: string | null
           scenarios?: string[] | null
           screenshot_url?: string | null
           status?: string | null
@@ -220,6 +264,9 @@ export type Database = {
         Update: {
           aggression?: string[] | null
           asset?: string
+          bias_snapshot?: Json
+          checklist?: Json
+          checklist_complete?: boolean
           created_at?: string
           direction?: string
           duration_minutes?: number | null
@@ -241,6 +288,7 @@ export type Database = {
           r_multiple?: number | null
           risk_amount?: number
           risk_tier?: string
+          session?: string | null
           scenarios?: string[] | null
           screenshot_url?: string | null
           status?: string | null
@@ -306,7 +354,18 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      v_current_bias: {
+        Row: {
+          bias: 'OOB_LONG' | 'OOB_SHORT' | 'MR_LONG' | 'MR_SHORT' | 'NONE'
+          confidence: 'LOW' | 'MEDIUM' | 'HIGH' | null
+          day_key: string
+          id: string
+          market_state: 'OUT_OF_BALANCE' | 'IN_BALANCE' | null
+          selected_at: string
+          tags: Json | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
       compute_daily_stats: {

--- a/src/lib/executionModels.ts
+++ b/src/lib/executionModels.ts
@@ -1,0 +1,114 @@
+export type ExecutionModel =
+  | 'TREND_IMPULSE_PB'
+  | 'TREND_VWAP_SIGMA'
+  | 'TREND_VALUE_MIGRATION'
+  | 'MR_FAIL_BREAKOUT_POC'
+  | 'MR_VA_FADE'
+  | 'MR_VWAP_REVERT';
+
+import type { MarketStateValue } from '@/types/bias';
+
+export const MODELS_BY_STATE: Record<MarketStateValue, ExecutionModel[]> = {
+  OUT_OF_BALANCE: [
+    'TREND_IMPULSE_PB',
+    'TREND_VWAP_SIGMA',
+    'TREND_VALUE_MIGRATION'
+  ],
+  IN_BALANCE: [
+    'MR_FAIL_BREAKOUT_POC',
+    'MR_VA_FADE',
+    'MR_VWAP_REVERT'
+  ]
+};
+
+interface ExecutionModelDetail {
+  label: string;
+  checklist: string[];
+  category: 'TREND' | 'MR';
+}
+
+export const EXECUTION_MODEL_DETAILS: Record<ExecutionModel, ExecutionModelDetail> = {
+  TREND_IMPULSE_PB: {
+    label: 'Trend • Impulse Pullback',
+    category: 'TREND',
+    checklist: [
+      'HTF aligns with OOB direction',
+      'Price outside value with trend control',
+      'Impulse leg followed by shallow pullback',
+      'CVD & imbalances backing the move',
+      'No opposite absorption at point of interest',
+      'Risk defined behind impulse origin'
+    ]
+  },
+  TREND_VWAP_SIGMA: {
+    label: 'Trend • VWAP σ Ride',
+    category: 'TREND',
+    checklist: [
+      'VWAP posture aligned with trend',
+      'Holding above σ1 and pressing toward σ2',
+      'No heavy counter absorption',
+      'Liquidity target remains ahead',
+      'Risk tucked under VWAP/σ reclaim'
+    ]
+  },
+  TREND_VALUE_MIGRATION: {
+    label: 'Trend • Value Migration',
+    category: 'TREND',
+    checklist: [
+      'POC / value shifting in trend direction',
+      'Pullback respects migrated value area',
+      'Continuation prints confirming migration',
+      'No topping divergence into entry',
+      'Risk placed behind migrated value'
+    ]
+  },
+  MR_FAIL_BREAKOUT_POC: {
+    label: 'MR • Failed Breakout to POC',
+    category: 'MR',
+    checklist: [
+      'Edge breakout failed and reclaimed',
+      'Acceptance building back inside value',
+      'Exhaustion where breakout failed',
+      'Primary target set to session POC',
+      'Risk placed beyond failed extreme'
+    ]
+  },
+  MR_VA_FADE: {
+    label: 'MR • Value Area Fade',
+    category: 'MR',
+    checklist: [
+      'Test & rejection of VAH/VAL',
+      'Day type showing non-trend behavior',
+      'Lack of aggression through the edge',
+      'Target planned toward mid / POC',
+      'Risk tucked beyond the value edge'
+    ]
+  },
+  MR_VWAP_REVERT: {
+    label: 'MR • VWAP Revert',
+    category: 'MR',
+    checklist: [
+      'Stretch extended from VWAP',
+      'Momentum waning / divergence showing',
+      'Entry planned on VWAP reclaim',
+      'Target anchored at VWAP',
+      'Risk set beyond stretch extreme'
+    ]
+  }
+};
+
+export const getExecutionModelLabel = (model?: ExecutionModel | null) => {
+  if (!model) return 'Select model';
+  return EXECUTION_MODEL_DETAILS[model]?.label ?? model;
+};
+
+export const getExecutionModelChecklist = (model?: ExecutionModel | null) => {
+  if (!model) return [];
+  return EXECUTION_MODEL_DETAILS[model]?.checklist ?? [];
+};
+
+export const isTrendModel = (model?: string | null) =>
+  typeof model === 'string' && model.startsWith('TREND');
+
+export const isMeanReversionModel = (model?: string | null) =>
+  typeof model === 'string' && model.startsWith('MR_');

--- a/src/types/bias.ts
+++ b/src/types/bias.ts
@@ -1,0 +1,54 @@
+export type BiasValue = 'OOB_LONG' | 'OOB_SHORT' | 'MR_LONG' | 'MR_SHORT' | 'NONE';
+export type MarketStateValue = 'OUT_OF_BALANCE' | 'IN_BALANCE';
+export type BiasConfidence = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export interface BiasStateSnapshot {
+  id?: string;
+  day_key?: string;
+  bias: BiasValue;
+  market_state: MarketStateValue | null;
+  confidence: BiasConfidence | null;
+  tags: string[] | null;
+  selected_at: string;
+  session?: string | null;
+}
+
+export const biasLabels: Record<BiasValue, string> = {
+  OOB_LONG: 'Bias: OOB Long',
+  OOB_SHORT: 'Bias: OOB Short',
+  MR_LONG: 'Bias: MR Long',
+  MR_SHORT: 'Bias: MR Short',
+  NONE: 'Bias: None'
+};
+
+export const biasTone: Record<BiasValue, 'emerald' | 'rose' | 'zinc'> = {
+  OOB_LONG: 'emerald',
+  MR_LONG: 'emerald',
+  OOB_SHORT: 'rose',
+  MR_SHORT: 'rose',
+  NONE: 'zinc'
+};
+
+export const marketStateLabels: Record<MarketStateValue, string> = {
+  OUT_OF_BALANCE: 'State: Out of Balance',
+  IN_BALANCE: 'State: In Balance'
+};
+
+export const marketStateTone: Record<MarketStateValue, 'amber'> = {
+  OUT_OF_BALANCE: 'amber',
+  IN_BALANCE: 'amber'
+};
+
+export const toneClasses: Record<string, string> = {
+  emerald: 'bg-emerald-500/10 border-emerald-400/40 text-emerald-200',
+  rose: 'bg-rose-500/10 border-rose-400/40 text-rose-200',
+  amber: 'bg-amber-500/10 border-amber-400/40 text-amber-200',
+  zinc: 'bg-zinc-500/10 border-zinc-400/40 text-zinc-200'
+};
+
+export interface BiasQuizResult {
+  bias: BiasValue;
+  market_state: MarketStateValue | null;
+  confidence: BiasConfidence | null;
+  tags: string[];
+}

--- a/supabase/migrations/20250928090000_bias_state.sql
+++ b/supabase/migrations/20250928090000_bias_state.sql
@@ -1,0 +1,78 @@
+DO $$
+BEGIN
+  CREATE TYPE public.bias_enum AS ENUM ('OOB_LONG', 'OOB_SHORT', 'MR_LONG', 'MR_SHORT', 'NONE');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.market_state_enum AS ENUM ('OUT_OF_BALANCE', 'IN_BALANCE');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.bias_state (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  day_key date NOT NULL,
+  bias public.bias_enum NOT NULL,
+  market_state public.market_state_enum,
+  confidence text,
+  tags jsonb,
+  selected_at timestamptz NOT NULL DEFAULT now(),
+  selected_by uuid REFERENCES auth.users (id),
+  active boolean NOT NULL DEFAULT true
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS bias_state_active_day_key
+  ON public.bias_state (day_key, active)
+  WHERE active;
+
+DROP VIEW IF EXISTS public.v_current_bias;
+CREATE VIEW public.v_current_bias AS
+SELECT DISTINCT ON (day_key)
+  day_key,
+  id,
+  bias,
+  market_state,
+  confidence,
+  tags,
+  selected_at
+FROM public.bias_state
+WHERE active
+ORDER BY day_key, selected_at DESC;
+
+ALTER TABLE public.trades
+  ADD COLUMN IF NOT EXISTS checklist jsonb;
+
+UPDATE public.trades
+SET checklist = '[]'::jsonb
+WHERE checklist IS NULL;
+
+ALTER TABLE public.trades
+  ALTER COLUMN checklist SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN checklist SET NOT NULL;
+
+ALTER TABLE public.trades
+  ADD COLUMN IF NOT EXISTS checklist_complete boolean;
+
+UPDATE public.trades
+SET checklist_complete = COALESCE(checklist_complete, false);
+
+ALTER TABLE public.trades
+  ALTER COLUMN checklist_complete SET DEFAULT false,
+  ALTER COLUMN checklist_complete SET NOT NULL;
+
+ALTER TABLE public.trades
+  ADD COLUMN IF NOT EXISTS bias_snapshot jsonb;
+
+UPDATE public.trades
+SET bias_snapshot = '{}'::jsonb
+WHERE bias_snapshot IS NULL;
+
+ALTER TABLE public.trades
+  ALTER COLUMN bias_snapshot SET DEFAULT '{}'::jsonb,
+  ALTER COLUMN bias_snapshot SET NOT NULL;
+
+ALTER TABLE public.trades
+  ADD COLUMN IF NOT EXISTS session text;


### PR DESCRIPTION
## Summary
- introduce a bias quiz modal and summary card that surface the active bias/market state across the dashboard
- gate execution model choices in the add-trade form behind the current bias, render model-specific checklists, and snapshot the context with each trade
- extend the Supabase schema with bias_state records, a view for the current bias, and new trade columns for checklist status and bias snapshots

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7cae84e848323bbc8d988a65625b4