### PR TITLE
Fix bias state API errors and enhance quiz flow

### DIFF
--- a/src/components/BiasQuizModal.tsx
+++ b/src/components/BiasQuizModal.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
 import type { BiasQuizResult, BiasConfidence } from '@/types/bias';
 import type { MarketStateValue } from '@/types/bias';
 import { getActiveSession, TRADING_SESSIONS } from '@/lib/tradingSessions';
+import { cn } from '@/lib/utils';
 
 interface BiasQuizModalProps {
   open: boolean;
@@ -117,11 +117,27 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
   const [quizState, setQuizState] = useState<QuizState>(() => defaultQuizState(getActiveSession()?.name ?? 'Unknown session'));
   const [step, setStep] = useState(0);
   const [submitting, setSubmitting] = useState(false);
+  const [orderFlowTouched, setOrderFlowTouched] = useState(false);
+  const autoAdvanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const resetState = useCallback((sessionName: string) => {
-    setQuizState(defaultQuizState(sessionName));
-    setStep(0);
+  const moveToStep = useCallback((nextStep: number) => {
+    setStep(nextStep);
+    setOrderFlowTouched(false);
   }, []);
+
+  const resetState = useCallback(
+    (sessionName?: string) => {
+      const resolvedSession = sessionName ?? getActiveSession()?.name ?? 'Unknown session';
+      setQuizState(defaultQuizState(resolvedSession));
+      setStep(0);
+      setOrderFlowTouched(false);
+      if (autoAdvanceTimer.current) {
+        clearTimeout(autoAdvanceTimer.current);
+        autoAdvanceTimer.current = null;
+      }
+    },
+    [autoAdvanceTimer]
+  );
 
   useEffect(() => {
     if (open) {
@@ -133,7 +149,55 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
     }
   }, [open, autoSession, resetState]);
 
+  useEffect(() => {
+    return () => {
+      if (autoAdvanceTimer.current) {
+        clearTimeout(autoAdvanceTimer.current);
+        autoAdvanceTimer.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (step !== 1) {
+      if (autoAdvanceTimer.current) {
+        clearTimeout(autoAdvanceTimer.current);
+        autoAdvanceTimer.current = null;
+      }
+      return;
+    }
+
+    if (!orderFlowTouched || quizState.orderFlow.length === 0) {
+      if (autoAdvanceTimer.current) {
+        clearTimeout(autoAdvanceTimer.current);
+        autoAdvanceTimer.current = null;
+      }
+      return;
+    }
+
+    if (autoAdvanceTimer.current) {
+      clearTimeout(autoAdvanceTimer.current);
+    }
+
+    autoAdvanceTimer.current = setTimeout(() => {
+      moveToStep(2);
+      autoAdvanceTimer.current = null;
+    }, 900);
+
+    return () => {
+      if (autoAdvanceTimer.current) {
+        clearTimeout(autoAdvanceTimer.current);
+        autoAdvanceTimer.current = null;
+      }
+    };
+  }, [step, orderFlowTouched, quizState.orderFlow, moveToStep]);
+
   const toggleOrderFlow = (choice: string) => {
+    if (autoAdvanceTimer.current) {
+      clearTimeout(autoAdvanceTimer.current);
+      autoAdvanceTimer.current = null;
+    }
+    setOrderFlowTouched(true);
     setQuizState(prev => {
       const exists = prev.orderFlow.includes(choice);
       let next = prev.orderFlow.filter(item => item !== choice);
@@ -149,47 +213,35 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
     });
   };
 
-  const canNext = () => {
-    switch (step) {
-      case 0:
-        return Boolean(quizState.location);
-      case 1:
-        return quizState.orderFlow.length > 0;
-      case 2:
-        return Boolean(quizState.structure);
-      case 3:
-        return Boolean(quizState.direction);
-      default:
-        return true;
-    }
-  };
-
-  const goNext = () => {
-    if (step < 4 && canNext()) {
-      setStep(step + 1);
-    }
-  };
-
   const goBack = () => {
-    if (step > 0) {
-      setStep(step - 1);
+    if (step === 0) return;
+    if (autoAdvanceTimer.current) {
+      clearTimeout(autoAdvanceTimer.current);
+      autoAdvanceTimer.current = null;
     }
+    setStep(prev => {
+      const next = Math.max(prev - 1, 0);
+      setOrderFlowTouched(false);
+      return next;
+    });
   };
 
   const handleComplete = async () => {
-    if (!canNext()) return;
+    if (!quizState.location || quizState.orderFlow.length === 0 || !quizState.structure || !quizState.direction) {
+      return;
+    }
     const result = mapToResult(quizState);
     setSubmitting(true);
     try {
       await onComplete(result);
       onOpenChange(false);
-      resetState();
+      resetState(autoSession);
     } catch (error) {
       console.error(error);
       toast({
         title: 'Unable to save bias',
         description: 'Something went wrong while saving your bias. Please try again.',
-        variant: 'destructive'
+        variant: 'destructive',
       });
     } finally {
       setSubmitting(false);
@@ -203,6 +255,9 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
     }
     return options;
   }, [autoSession]);
+
+  const showAutoAdvanceNotice = step === 1 && orderFlowTouched && quizState.orderFlow.length > 0;
+  const quizComplete = Boolean(quizState.location) && quizState.orderFlow.length > 0 && Boolean(quizState.structure) && Boolean(quizState.direction);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -219,11 +274,10 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
               {Array.from({ length: 5 }).map((_, index) => (
                 <span
                   key={index}
-                  className={
-                    index <= step
-                      ? 'h-1.5 w-6 rounded-full bg-indigo-400'
-                      : 'h-1.5 w-6 rounded-full bg-slate-700'
-                  }
+                  className={cn(
+                    'h-1.5 w-6 rounded-full bg-slate-700/80 transition-colors',
+                    index <= step && 'bg-indigo-500'
+                  )}
                 />
               ))}
             </div>
@@ -233,17 +287,27 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
             <section>
               <h3 className="text-base font-semibold text-foreground">Where is price relative to value/VWAP?</h3>
               <div className="mt-3 grid grid-cols-1 gap-2">
-                {LOCATION_OPTIONS.map(option => (
-                  <Button
-                    key={option}
-                    type="button"
-                    variant={quizState.location === option ? 'default' : 'outline'}
-                    className="justify-start rounded-xl border border-slate-700 bg-slate-900/40 py-6 text-left text-sm"
-                    onClick={() => setQuizState(prev => ({ ...prev, location: option }))}
-                  >
-                    {option}
-                  </Button>
-                ))}
+                {LOCATION_OPTIONS.map(option => {
+                  const isSelected = quizState.location === option;
+                  return (
+                    <Button
+                      key={option}
+                      type="button"
+                      variant="ghost"
+                      className={cn(
+                        'justify-start rounded-xl border py-6 text-left text-sm transition-colors',
+                        'border-slate-700/70 bg-slate-900/40 text-slate-200 hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-50',
+                        isSelected && 'border-indigo-400/80 bg-indigo-500/20 text-indigo-50 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]'
+                      )}
+                      onClick={() => {
+                        setQuizState(prev => ({ ...prev, location: option }));
+                        moveToStep(1);
+                      }}
+                    >
+                      {option}
+                    </Button>
+                  );
+                })}
               </div>
             </section>
           )}
@@ -256,14 +320,19 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
                 {ORDER_FLOW_OPTIONS.map(option => {
                   const isSelected = quizState.orderFlow.includes(option);
                   return (
-                    <Badge
+                    <button
                       key={option}
-                      variant={isSelected ? 'default' : 'outline'}
-                      className="cursor-pointer rounded-full px-4 py-2 text-sm"
+                      type="button"
+                      className={cn(
+                        'rounded-full border px-4 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-0',
+                        isSelected
+                          ? 'border-indigo-400/80 bg-indigo-500/20 text-indigo-100 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]'
+                          : 'border-slate-700/70 bg-slate-900/40 text-slate-200 hover:border-indigo-400/50 hover:bg-indigo-500/10 hover:text-indigo-50'
+                      )}
                       onClick={() => toggleOrderFlow(option)}
                     >
                       {option}
-                    </Badge>
+                    </button>
                   );
                 })}
               </div>
@@ -275,37 +344,58 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
               <div>
                 <h3 className="text-base font-semibold text-foreground">Structure right now?</h3>
                 <div className="mt-3 grid grid-cols-1 gap-2">
-                  {STRUCTURE_OPTIONS.map(option => (
-                    <Button
-                      key={option}
-                      type="button"
-                      variant={quizState.structure === option ? 'default' : 'outline'}
-                      className="justify-start rounded-xl border border-slate-700 bg-slate-900/40 py-5 text-left text-sm"
-                      onClick={() => setQuizState(prev => ({ ...prev, structure: option }))}
-                    >
-                      {option}
-                    </Button>
-                  ))}
+                  {STRUCTURE_OPTIONS.map(option => {
+                    const isSelected = quizState.structure === option;
+                    return (
+                      <Button
+                        key={option}
+                        type="button"
+                        variant="ghost"
+                        className={cn(
+                          'justify-start rounded-xl border py-5 text-left text-sm transition-colors',
+                          'border-slate-700/70 bg-slate-900/40 text-slate-200 hover:border-indigo-400/60 hover:bg-indigo-500/10 hover:text-indigo-50',
+                          isSelected && 'border-indigo-400/80 bg-indigo-500/20 text-indigo-50 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]'
+                        )}
+                        onClick={() => {
+                          setQuizState(prev => ({ ...prev, structure: option }));
+                          moveToStep(3);
+                        }}
+                      >
+                        {option}
+                      </Button>
+                    );
+                  })}
                 </div>
               </div>
               <div>
                 <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Session</h4>
                 <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
-                  {sessionOptions.map(option => (
-                    <Button
-                      key={option}
-                      type="button"
-                      variant={quizState.session === option ? 'default' : 'outline'}
-                      className="justify-center rounded-xl border border-slate-700 bg-slate-900/40 py-3"
-                      onClick={() => setQuizState(prev => ({ ...prev, session: option }))}
-                    >
-                      {option}
-                    </Button>
-                  ))}
+                  {sessionOptions.map(option => {
+                    const isSelected = quizState.session === option;
+                    return (
+                      <Button
+                        key={option}
+                        type="button"
+                        variant="ghost"
+                        className={cn(
+                          'justify-center rounded-xl border py-3 transition-colors',
+                          'border-slate-700/70 bg-slate-900/40 text-slate-200 hover:border-indigo-400/50 hover:bg-indigo-500/10 hover:text-indigo-50',
+                          isSelected && 'border-indigo-400/80 bg-indigo-500/20 text-indigo-50 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]'
+                        )}
+                        onClick={() => setQuizState(prev => ({ ...prev, session: option }))}
+                      >
+                        {option}
+                      </Button>
+                    );
+                  })}
                   <Button
                     type="button"
-                    variant={quizState.session === 'Override' ? 'default' : 'outline'}
-                    className="justify-center rounded-xl border border-slate-700 bg-slate-900/40 py-3"
+                    variant="ghost"
+                    className={cn(
+                      'justify-center rounded-xl border py-3 transition-colors',
+                      'border-slate-700/70 bg-slate-900/40 text-slate-200 hover:border-indigo-400/50 hover:bg-indigo-500/10 hover:text-indigo-50',
+                      quizState.session === 'Override' && 'border-indigo-400/80 bg-indigo-500/20 text-indigo-50 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]'
+                    )}
                     onClick={() => setQuizState(prev => ({ ...prev, session: 'Override' }))}
                   >
                     Override
@@ -321,17 +411,31 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
               <div className="mt-3 grid grid-cols-2 gap-3">
                 <Button
                   type="button"
-                  variant={quizState.direction === 'LONG' ? 'default' : 'outline'}
-                  className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 py-6 text-base"
-                  onClick={() => setQuizState(prev => ({ ...prev, direction: 'LONG' }))}
+                  variant="ghost"
+                  className={cn(
+                    'rounded-xl border py-6 text-base transition-colors',
+                    'border-emerald-500/40 bg-emerald-500/10 text-emerald-200/80 hover:border-emerald-400 hover:bg-emerald-500/20 hover:text-emerald-50',
+                    quizState.direction === 'LONG' && 'border-emerald-400 bg-emerald-500/20 text-emerald-50 shadow-[0_0_0_1px_rgba(16,185,129,0.45)]'
+                  )}
+                  onClick={() => {
+                    setQuizState(prev => ({ ...prev, direction: 'LONG' }));
+                    moveToStep(4);
+                  }}
                 >
                   Long
                 </Button>
                 <Button
                   type="button"
-                  variant={quizState.direction === 'SHORT' ? 'default' : 'outline'}
-                  className="rounded-xl border border-rose-500/40 bg-rose-500/10 py-6 text-base"
-                  onClick={() => setQuizState(prev => ({ ...prev, direction: 'SHORT' }))}
+                  variant="ghost"
+                  className={cn(
+                    'rounded-xl border py-6 text-base transition-colors',
+                    'border-rose-500/40 bg-rose-500/10 text-rose-200/80 hover:border-rose-400 hover:bg-rose-500/20 hover:text-rose-50',
+                    quizState.direction === 'SHORT' && 'border-rose-400 bg-rose-500/20 text-rose-50 shadow-[0_0_0_1px_rgba(244,63,94,0.45)]'
+                  )}
+                  onClick={() => {
+                    setQuizState(prev => ({ ...prev, direction: 'SHORT' }));
+                    moveToStep(4);
+                  }}
                 >
                   Short
                 </Button>
@@ -343,40 +447,48 @@ export function BiasQuizModal({ open, onOpenChange, onComplete }: BiasQuizModalP
             <section>
               <h3 className="text-base font-semibold text-foreground">Confidence (optional)</h3>
               <div className="mt-3 flex flex-wrap gap-2">
-                {CONFIDENCE_OPTIONS.map(option => (
-                  <Button
-                    key={option}
-                    type="button"
-                    variant={quizState.confidence === option ? 'default' : 'outline'}
-                    className="rounded-full px-4 py-2 text-sm"
-                    onClick={() =>
-                      setQuizState(prev => ({
-                        ...prev,
-                        confidence: prev.confidence === option ? null : option
-                      }))
-                    }
-                  >
-                    {option.toLowerCase()}
-                  </Button>
-                ))}
+                {CONFIDENCE_OPTIONS.map(option => {
+                  const isSelected = quizState.confidence === option;
+                  return (
+                    <Button
+                      key={option}
+                      type="button"
+                      variant="ghost"
+                      className={cn(
+                        'rounded-full border px-4 py-2 text-sm transition-colors',
+                        'border-slate-700/70 bg-slate-900/40 text-slate-200 hover:border-indigo-400/50 hover:bg-indigo-500/10 hover:text-indigo-50',
+                        isSelected && 'border-indigo-400/80 bg-indigo-500/20 text-indigo-50 shadow-[0_0_0_1px_rgba(99,102,241,0.35)]'
+                      )}
+                      onClick={() =>
+                        setQuizState(prev => ({
+                          ...prev,
+                          confidence: prev.confidence === option ? null : option,
+                        }))
+                      }
+                    >
+                      {option.toLowerCase()}
+                    </Button>
+                  );
+                })}
               </div>
             </section>
           )}
         </div>
 
-        <div className="mt-6 flex items-center justify-between">
-          <Button variant="ghost" onClick={goBack} disabled={step === 0 || submitting}>
-            Back
-          </Button>
-          {step < 4 ? (
-            <Button onClick={goNext} disabled={!canNext()}>
-              Next
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-h-[1.5rem] text-xs text-indigo-200/80">
+            {showAutoAdvanceNotice && <span>Moving forward once selections settle…</span>}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={goBack} disabled={step === 0 || submitting}>
+              Back
             </Button>
-          ) : (
-            <Button onClick={handleComplete} disabled={submitting || !canNext()}>
-              {submitting ? 'Saving…' : 'Confirm'}
-            </Button>
-          )}
+            {step === 4 && (
+              <Button onClick={handleComplete} disabled={submitting || !quizComplete}>
+                {submitting ? 'Saving…' : 'Save bias'}
+              </Button>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -372,6 +372,20 @@ export type Database = {
         Args: { target_date: string; target_user_id: string }
         Returns: Json
       }
+      get_current_bias: {
+        Args: { target_day: string }
+        Returns: Database['public']['Tables']['bias_state']['Row'] | null
+      }
+      set_bias_state: {
+        Args: {
+          target_day: string
+          target_bias: Database['public']['Tables']['bias_state']['Row']['bias']
+          target_market_state?: Database['public']['Tables']['bias_state']['Row']['market_state'] | null
+          target_confidence?: Database['public']['Tables']['bias_state']['Row']['confidence'] | null
+          target_tags?: string[] | null
+        }
+        Returns: Database['public']['Tables']['bias_state']['Row']
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/shims/lodashRoot.js
+++ b/src/shims/lodashRoot.js
@@ -1,0 +1,13 @@
+const freeGlobal = require('lodash/_freeGlobal');
+
+const globalThisFallback = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  return {};
+})();
+
+const root = freeGlobal || globalThisFallback;
+
+module.exports = root;

--- a/supabase/migrations/20241006120000_bias_state_functions.sql
+++ b/supabase/migrations/20241006120000_bias_state_functions.sql
@@ -1,0 +1,67 @@
+create or replace function public.get_current_bias(target_day date)
+returns public.bias_state
+language sql
+security definer
+set search_path = public, extensions
+as $$
+  select bs
+  from public.bias_state as bs
+  where bs.day_key = target_day
+    and bs.active
+  order by bs.selected_at desc
+  limit 1;
+$$;
+
+grant execute on function public.get_current_bias(date) to anon;
+grant execute on function public.get_current_bias(date) to authenticated;
+
+create or replace function public.set_bias_state(
+  target_day date,
+  target_bias public.bias_enum,
+  target_market_state public.market_state_enum default null,
+  target_confidence text default null,
+  target_tags text[] default null
+)
+returns public.bias_state
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_selected_by uuid := auth.uid();
+  v_inserted public.bias_state;
+begin
+  if v_selected_by is null then
+    raise exception 'Missing authenticated user for bias selection';
+  end if;
+
+  update public.bias_state
+     set active = false
+   where day_key = target_day
+     and active;
+
+  insert into public.bias_state (
+    day_key,
+    bias,
+    market_state,
+    confidence,
+    tags,
+    selected_by,
+    active
+  )
+  values (
+    target_day,
+    target_bias,
+    target_market_state,
+    target_confidence,
+    case when target_tags is null then null else to_jsonb(target_tags) end,
+    v_selected_by,
+    true
+  )
+  returning * into v_inserted;
+
+  return v_inserted;
+end;
+$$;
+
+grant execute on function public.set_bias_state(date, public.bias_enum, public.market_state_enum, text, text[]) to authenticated;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "lodash/_root.js": path.resolve(__dirname, "./src/shims/lodashRoot.js"),
     },
   },
 }));


### PR DESCRIPTION
## Summary
- add Supabase functions and types to manage bias state without direct table access
- update the bias state hook to use the new RPC endpoints
- refresh the bias quiz UI with auto-advance interactions and improved selection styling while adding a lodash root shim to avoid CSP issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d0fa552c8323b1d70ed506243dde