### PR TITLE
feat: add Supabase bias schema migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Bias tracking & Supabase setup
+
+Bias tracking in the trading dashboard depends on Supabase tables, views, and RPC functions that ship with this
+repository. If you open the app and see a yellow banner that reads “Bias tracking configuration missing – Bias state
+storage is not available. Please run the latest Supabase migrations to enable bias tracking.” it simply means those
+Supabase migrations have not been applied yet.
+
+To fix the warning:
+
+1. Install the [Supabase CLI](https://supabase.com/docs/reference/cli/usage) (once per machine).
+2. Start your local Supabase stack or link a remote project: `supabase start`
+3. Apply the bundled migrations: `supabase db reset`
+4. Refresh the dashboard – the warning disappears once the schema exists.
+
+More detail lives in [`docs/troubleshooting/bias-tracking.md`](docs/troubleshooting/bias-tracking.md).
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/d50e12b5-8df8-4c0c-a24b-c1a69cb79a1d) and click on Share -> Publish.

--- a/docs/troubleshooting/bias-tracking.md
+++ b/docs/troubleshooting/bias-tracking.md
@@ -1,0 +1,71 @@
+# Bias tracking Supabase schema
+
+The trading dashboard reads and writes the current bias through Supabase. All of the SQL objects it depends on
+(functions, views, tables) live in the migrations contained in `supabase/migrations/`.
+
+When those migrations have not been applied you will see a yellow banner in the app that reads:
+
+```
+Bias tracking configuration missing
+Bias state storage is not available. Please run the latest Supabase migrations to enable bias tracking.
+```
+
+This is expected – it means the local/linked Supabase project is still missing the bias schema. Apply the migrations to
+enable the feature:
+
+1. Install the [Supabase CLI](https://supabase.com/docs/reference/cli/usage) if you have not already.
+2. Start your local stack (or link a remote project):
+   ```bash
+   supabase start
+   ```
+3. Apply the migrations that ship with this repo:
+   ```bash
+   supabase db reset
+   ```
+   This command re-applies every SQL migration in `supabase/migrations/` against the linked database, including
+   [`20241010123000_bias_tracking_storage.sql`](../../supabase/migrations/20241010123000_bias_tracking_storage.sql)
+   which provisions the bias storage table, unique index, and row-level security policies.
+4. Regenerate the generated types if you are running locally:
+   ```bash
+   supabase gen types typescript --project-id "$(supabase status -o json | jq -r '.project.id')" --schema public > src/integrations/supabase/types.ts
+   ```
+   The `jq` call extracts the project id from the CLI output; feel free to hard-code the id if you prefer. (You can also
+   add an npm script such as `generate:supabase-types` to wrap this command.)
+
+After the migrations finish successfully refresh the dashboard. The warning disappears and you can save bias states.
+
+If you are running against a remote Supabase project make sure it is linked with `supabase link --project-ref <ref>` and
+rerun `supabase db push` to apply only the new migrations.
+
+## Manual SQL deployment & verification
+
+Want to run the SQL by hand? The migration mentioned above contains the following key steps:
+
+- Ensure the `bias_enum` and `market_state_enum` enums exist.
+- Create the `public.bias_state` table with the columns used by the app (day key, bias enums, optional tags, etc.).
+- Enable row-level security and add permissive policies so authenticated users can read and persist the shared bias state.
+
+You can run that file manually with either approach:
+
+```bash
+# Apply the SQL locally with the Supabase CLI
+supabase db push
+
+# ...or connect with psql and run the file manually
+psql "$SUPABASE_DB_URL" -f supabase/migrations/20241010123000_bias_tracking_storage.sql
+```
+
+After the migration succeeds, verify the schema:
+
+```sql
+-- Confirm the table exists and shows the expected columns
+\d public.bias_state
+
+-- Check the RLS policies
+SELECT policyname, permissive, roles, cmd FROM pg_policies WHERE tablename = 'bias_state';
+
+-- Optional: confirm you can read/write a row
+SELECT * FROM public.bias_state LIMIT 1;
+```
+
+Once those checks succeed, reload the dashboard—the banner disappears and bias tracking is ready to go.

--- a/supabase/migrations/20241010123000_bias_tracking_storage.sql
+++ b/supabase/migrations/20241010123000_bias_tracking_storage.sql
@@ -1,0 +1,82 @@
+-- Bias tracking schema hardening
+-- Ensures the bias_state table, supporting enums, and RLS policies exist so the app can persist selections.
+
+-- Create enum types if they are missing (idempotent)
+DO $$
+BEGIN
+  CREATE TYPE public.bias_enum AS ENUM ('OOB_LONG', 'OOB_SHORT', 'MR_LONG', 'MR_SHORT', 'NONE');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.market_state_enum AS ENUM ('OUT_OF_BALANCE', 'IN_BALANCE');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END$$;
+
+-- Create the bias_state table if it does not already exist
+CREATE TABLE IF NOT EXISTS public.bias_state (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  day_key date NOT NULL,
+  bias public.bias_enum NOT NULL,
+  market_state public.market_state_enum,
+  confidence text,
+  tags jsonb,
+  selected_at timestamptz NOT NULL DEFAULT now(),
+  selected_by uuid REFERENCES auth.users (id),
+  active boolean NOT NULL DEFAULT true
+);
+
+-- Preserve non-null constraints and defaults even if the table existed before
+ALTER TABLE public.bias_state
+  ALTER COLUMN day_key SET NOT NULL,
+  ALTER COLUMN bias SET NOT NULL,
+  ALTER COLUMN selected_at SET NOT NULL,
+  ALTER COLUMN active SET NOT NULL,
+  ALTER COLUMN selected_at SET DEFAULT now(),
+  ALTER COLUMN active SET DEFAULT true;
+
+-- Ensure the selected_by column references auth.users (if it already does, the exception is ignored)
+DO $$
+BEGIN
+  ALTER TABLE public.bias_state
+    ADD CONSTRAINT bias_state_selected_by_fkey
+    FOREIGN KEY (selected_by) REFERENCES auth.users(id);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END$$;
+
+-- Helpful index so only one active entry exists per day
+CREATE UNIQUE INDEX IF NOT EXISTS bias_state_active_day_key
+  ON public.bias_state (day_key, active)
+  WHERE active;
+
+-- Enable row level security and allow authenticated users to work with the bias state
+ALTER TABLE public.bias_state ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Bias state select"
+  ON public.bias_state
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY IF NOT EXISTS "Bias state insert"
+  ON public.bias_state
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS "Bias state update"
+  ON public.bias_state
+  FOR UPDATE
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS "Bias state delete"
+  ON public.bias_state
+  FOR DELETE
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## Summary
- add a Supabase migration that ensures the bias_state enums, table, and RLS policies exist
- extend the troubleshooting guide with manual SQL deployment and verification steps for the bias schema

## Testing
- not run (sql/docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d7efe954488323946313438050bf38