### PR TITLE
Use direct Supabase bias_state query by default

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_BIAS_RPC?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- gate the get_current_bias RPC behind a Vite flag so the hook defaults to the existing direct table fallback
- limit the bias_state select to the fields needed for the snapshot mapping
- declare the new Vite environment variable in the project typings

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d81bc4f7948323a970615c97a94d38