### PR TITLE
Handle Supabase column cache errors

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -57,6 +57,7 @@ const isMissingRelationError = (error: PostgrestError | null): boolean => {
 
   if (
     normalizedCode === 'PGRST205' ||
+    normalizedCode === 'PGRST204' ||
     normalizedCode === 'PGRST101' ||
     normalizedCode === 'PGRST201' ||
     normalizedCode === '42P01'
@@ -68,7 +69,9 @@ const isMissingRelationError = (error: PostgrestError | null): boolean => {
   return (
     message.includes('could not find the table') ||
     message.includes('could not find the view') ||
-    message.includes('relation does not exist')
+    message.includes('relation does not exist') ||
+    message.includes('column does not exist') ||
+    (message.includes('could not find the') && message.includes('column'))
   );
 };
 


### PR DESCRIPTION
## Summary
- treat PostgREST PGRST204 column cache errors the same as missing relations when saving bias state
- extend error message parsing to detect missing column responses so the app can fall back to the local bias cache

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8272d95c88323b814daa8931a690a