### PR TITLE
Handle outdated bias RPC signature gracefully

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -50,6 +50,19 @@ const isMissingFunctionError = (error: PostgrestError | null): boolean => {
   );
 };
 
+const isMismatchedFunctionSignatureError = (error: PostgrestError | null): boolean => {
+  if (!error) return false;
+
+  const normalizedCode = error.code?.trim().toUpperCase();
+
+  if (normalizedCode === '22P02') {
+    return true;
+  }
+
+  const message = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase();
+  return message.includes('invalid input syntax') || message.includes('function return type mismatch');
+};
+
 const isMissingRelationError = (error: PostgrestError | null): boolean => {
   if (!error) return false;
 
@@ -488,15 +501,15 @@ export function useBiasState() {
         });
 
         if (error) {
-          if (isMissingFunctionError(error)) {
+          if (isMissingFunctionError(error) || isMismatchedFunctionSignatureError(error)) {
             console.warn(
-              'set_bias_state function missing. Falling back to direct table mutation. Run the latest Supabase migrations to enable RPC support.'
+              'set_bias_state function is unavailable or has an outdated signature. Falling back to direct table mutation. Run the latest Supabase migrations to enable bias tracking.'
             );
 
             markSchemaStatus('rpc', 'missing');
             if (!schemaMessage) {
               setSchemaMessage(
-                'Bias RPC functions are unavailable. Please run the latest Supabase migrations to enable bias tracking.'
+                'Bias RPC functions are unavailable or out of date. Please run the latest Supabase migrations to enable bias tracking.'
               );
             }
 


### PR DESCRIPTION
## Summary
- detect invalid input errors from the `set_bias_state` RPC and treat them as outdated signatures
- fall back to direct table updates and improve messaging when the RPC is unavailable or outdated

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8efcd77a08323a499eec512cabd6b