### PR TITLE
Fix bias state confidence schema mismatches

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -229,7 +229,7 @@ export function useBiasState() {
       .select('*')
       .eq('active', true)
       .eq('day_key', dayKey)
-      .order('created_at', { ascending: false })
+      .order('selected_at', { ascending: false })
       .limit(1)
       .maybeSingle();
 
@@ -463,7 +463,7 @@ export function useBiasState() {
         .select('*')
         .eq('day_key', dayKey)
         .eq('active', true)
-        .order('created_at', { ascending: false })
+        .order('selected_at', { ascending: false })
         .limit(1)
         .maybeSingle();
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -43,43 +43,37 @@ export type Database = {
       }
       bias_state: {
         Row: {
-          active: boolean | null
-          bias: string | null
-          confidence: number | null
-          created_at: string | null
+          active: boolean
+          bias: Database["public"]["Enums"]["bias_enum"]
+          confidence: string | null
           day_key: string
-          id: number
-          market_state: string | null
-          selected_at: string | null
+          id: string
+          market_state: Database["public"]["Enums"]["market_state_enum"] | null
+          selected_at: string
           selected_by: string | null
-          tags: string[] | null
-          updated_at: string | null
+          tags: Json | null
         }
         Insert: {
-          active?: boolean | null
-          bias?: string | null
-          confidence?: number | null
-          created_at?: string | null
+          active?: boolean
+          bias: Database["public"]["Enums"]["bias_enum"]
+          confidence?: string | null
           day_key: string
-          id?: never
-          market_state?: string | null
-          selected_at?: string | null
+          id?: string
+          market_state?: Database["public"]["Enums"]["market_state_enum"] | null
+          selected_at?: string
           selected_by?: string | null
-          tags?: string[] | null
-          updated_at?: string | null
+          tags?: Json | null
         }
         Update: {
-          active?: boolean | null
-          bias?: string | null
-          confidence?: number | null
-          created_at?: string | null
+          active?: boolean
+          bias?: Database["public"]["Enums"]["bias_enum"]
+          confidence?: string | null
           day_key?: string
-          id?: never
-          market_state?: string | null
-          selected_at?: string | null
+          id?: string
+          market_state?: Database["public"]["Enums"]["market_state_enum"] | null
+          selected_at?: string
           selected_by?: string | null
-          tags?: string[] | null
-          updated_at?: string | null
+          tags?: Json | null
         }
         Relationships: []
       }
@@ -378,18 +372,36 @@ export type Database = {
       v_current_bias: {
         Row: {
           active: boolean | null
-          created_at: string | null
+          bias: Database["public"]["Enums"]["bias_enum"] | null
+          confidence: string | null
           day_key: string | null
+          id: string | null
+          market_state: Database["public"]["Enums"]["market_state_enum"] | null
+          selected_at: string | null
+          selected_by: string | null
+          tags: Json | null
         }
         Insert: {
           active?: boolean | null
-          created_at?: string | null
+          bias?: Database["public"]["Enums"]["bias_enum"] | null
+          confidence?: string | null
           day_key?: string | null
+          id?: string | null
+          market_state?: Database["public"]["Enums"]["market_state_enum"] | null
+          selected_at?: string | null
+          selected_by?: string | null
+          tags?: Json | null
         }
         Update: {
           active?: boolean | null
-          created_at?: string | null
+          bias?: Database["public"]["Enums"]["bias_enum"] | null
+          confidence?: string | null
           day_key?: string | null
+          id?: string | null
+          market_state?: Database["public"]["Enums"]["market_state_enum"] | null
+          selected_at?: string | null
+          selected_by?: string | null
+          tags?: Json | null
         }
         Relationships: []
       }
@@ -400,26 +412,24 @@ export type Database = {
         Returns: Json
       }
       get_current_bias: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          active: boolean
-          created_at: string
-          day_key: string
-        }[]
+        Args: { target_day: string }
+        Returns: Database["public"]["Tables"]["bias_state"]["Row"] | null
       }
       set_bias_state: {
         Args: {
-          target_bias?: string
-          target_confidence?: number
-          target_day?: string
-          target_market_state?: string
+          target_bias: Database["public"]["Enums"]["bias_enum"]
+          target_confidence?: string
+          target_day: string
+          target_market_state?: Database["public"]["Enums"]["market_state_enum"]
           target_tags?: string[]
         }
-        Returns: undefined
+        Returns: Database["public"]["Tables"]["bias_state"]["Row"]
       }
     }
     Enums: {
+      bias_enum: "OOB_LONG" | "OOB_SHORT" | "MR_LONG" | "MR_SHORT" | "NONE"
       bias_level: "low" | "medium" | "high"
+      market_state_enum: "OUT_OF_BALANCE" | "IN_BALANCE"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/20251015120000_bias_confidence_text.sql
+++ b/supabase/migrations/20251015120000_bias_confidence_text.sql
@@ -1,0 +1,105 @@
+-- Ensure the bias_state confidence column accepts descriptive text values
+-- and refresh dependent helpers so Supabase always returns the expected
+-- shape.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'bias_state'
+      AND column_name = 'confidence'
+  ) THEN
+    RETURN;
+  END IF;
+END $$;
+
+ALTER TABLE public.bias_state
+  ALTER COLUMN confidence TYPE text
+  USING CASE
+    WHEN confidence IS NULL THEN NULL
+    ELSE confidence::text
+  END;
+
+DROP VIEW IF EXISTS public.v_current_bias;
+CREATE VIEW public.v_current_bias AS
+SELECT DISTINCT ON (day_key)
+  day_key,
+  id,
+  bias,
+  market_state,
+  confidence,
+  tags,
+  selected_at,
+  selected_by,
+  active
+FROM public.bias_state
+WHERE active
+ORDER BY day_key, selected_at DESC;
+
+CREATE OR REPLACE FUNCTION public.get_current_bias(target_day date)
+RETURNS public.bias_state
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+  SELECT bs
+  FROM public.bias_state AS bs
+  WHERE bs.day_key = target_day
+    AND bs.active
+  ORDER BY bs.selected_at DESC
+  LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_bias_state(
+  target_day date,
+  target_bias public.bias_enum,
+  target_market_state public.market_state_enum DEFAULT NULL,
+  target_confidence text DEFAULT NULL,
+  target_tags text[] DEFAULT NULL
+)
+RETURNS public.bias_state
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_selected_by uuid := auth.uid();
+  v_inserted public.bias_state;
+BEGIN
+  IF v_selected_by IS NULL THEN
+    RAISE EXCEPTION 'Missing authenticated user for bias selection';
+  END IF;
+
+  UPDATE public.bias_state
+     SET active = FALSE
+   WHERE day_key = target_day
+     AND active;
+
+  INSERT INTO public.bias_state (
+    day_key,
+    bias,
+    market_state,
+    confidence,
+    tags,
+    selected_by,
+    active
+  )
+  VALUES (
+    target_day,
+    target_bias,
+    target_market_state,
+    target_confidence,
+    CASE WHEN target_tags IS NULL THEN NULL ELSE to_jsonb(target_tags) END,
+    v_selected_by,
+    TRUE
+  )
+  RETURNING * INTO v_inserted;
+
+  RETURN v_inserted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_current_bias(date) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_current_bias(date) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_bias_state(date, public.bias_enum, public.market_state_enum, text, text[]) TO authenticated;


### PR DESCRIPTION
## Summary
- migrate the bias_state confidence column to text and refresh the helper view and RPCs
- align the generated Supabase TypeScript types with the updated bias_state schema
- fix the bias state fallback queries to order by the selected timestamp field

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f5f8e18083239bc3223db26cdc2a