### PR TITLE
Fix saveBiasState data destructuring

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -492,7 +492,7 @@ export function useBiasState() {
       setSaving(true);
 
       try {
-        const { error } = await supabase.rpc('set_bias_state', {
+        const { data, error } = await supabase.rpc('set_bias_state', {
           target_day: dayKey,
           target_bias: result.bias,
           target_market_state: result.market_state ?? null,


### PR DESCRIPTION
## Summary
- include the Supabase RPC response payload when saving the bias state so that the fallback snapshot logic can run without reference errors

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f89c7dc883239b1ce57088eea5ad