### PR TITLE
Fix set_bias_state migration confidence type

### DIFF
--- a/supabase/migrations/20250928075902_b54f27b0-db9c-4a51-9d8b-f54b0e5e0267.sql
+++ b/supabase/migrations/20250928075902_b54f27b0-db9c-4a51-9d8b-f54b0e5e0267.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION public.set_bias_state(
   target_day date DEFAULT CURRENT_DATE,
   target_bias text DEFAULT NULL,
   target_market_state text DEFAULT NULL,
-  target_confidence integer DEFAULT NULL,
+  target_confidence text DEFAULT NULL,
   target_tags text[] DEFAULT NULL
 )
 RETURNS void


### PR DESCRIPTION
## Summary
- align the earliest set_bias_state migration signature so target_confidence is stored as text, matching later overloads

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d90ac1456483238c7d8daed0d7f603