### PR TITLE
Log Supabase RPC errors with payload

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -501,6 +501,15 @@ export function useBiasState() {
         });
 
         if (error) {
+          console.error('RPC Error Details:', error);
+          console.log('Parameters sent:', {
+            target_day: dayKey,
+            target_bias: result.bias,
+            target_market_state: result.market_state ?? null,
+            target_confidence: result.confidence ?? null,
+            target_tags: result.tags.length ? result.tags : null,
+          });
+
           if (isMissingFunctionError(error) || isMismatchedFunctionSignatureError(error)) {
             console.warn(
               'set_bias_state function is unavailable or has an outdated signature. Falling back to direct table mutation. Run the latest Supabase migrations to enable bias tracking.'


### PR DESCRIPTION
## Summary
- log the Supabase `set_bias_state` RPC error details and payload parameters for easier debugging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d90cefdcf48323873dc7bb359c064c