### PR TITLE
Update bias state RPC call name

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -492,7 +492,7 @@ export function useBiasState() {
       setSaving(true);
 
       try {
-        const { data, error } = await supabase.rpc('set_bias_state', {
+        const { data, error } = await supabase.rpc('set_daily_bias_state', {
           target_day: dayKey,
           target_bias: result.bias,
           target_market_state: result.market_state ?? null,
@@ -512,7 +512,7 @@ export function useBiasState() {
 
           if (isMissingFunctionError(error) || isMismatchedFunctionSignatureError(error)) {
             console.warn(
-              'set_bias_state function is unavailable or has an outdated signature. Falling back to direct table mutation. Run the latest Supabase migrations to enable bias tracking.'
+              'set_daily_bias_state function is unavailable or has an outdated signature. Falling back to direct table mutation. Run the latest Supabase migrations to enable bias tracking.'
             );
 
             markSchemaStatus('rpc', 'missing');

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -415,7 +415,7 @@ export type Database = {
         Args: { target_day: string }
         Returns: Database["public"]["Tables"]["bias_state"]["Row"] | null
       }
-      set_bias_state: {
+      set_daily_bias_state: {
         Args: {
           target_bias: Database["public"]["Enums"]["bias_enum"]
           target_confidence?: string


### PR DESCRIPTION
## Summary
- update the bias state save flow to call the renamed `set_daily_bias_state` Supabase function
- align generated Supabase types with the new RPC function name

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9107150148323bc404237123ef9aa