### PR TITLE
Fix bias state display after saving

### DIFF
--- a/src/hooks/useBiasState.tsx
+++ b/src/hooks/useBiasState.tsx
@@ -467,9 +467,11 @@ export function useBiasState() {
         .limit(1)
         .maybeSingle();
 
-      const snapshot = newRecord ? mapRowToSnapshot(newRecord) : null;
+      let snapshot = newRecord ? mapRowToSnapshot(newRecord) : null;
       if (snapshot) {
         clearLocalBias();
+      } else {
+        snapshot = createLocalSnapshot(result);
       }
       setBiasState(snapshot);
     },
@@ -542,16 +544,26 @@ export function useBiasState() {
           throw error;
         }
 
-        const snapshot = data ? mapRowToSnapshot(data) : null;
+        let snapshot = data ? mapRowToSnapshot(data) : null;
         if (snapshot) {
           clearLocalBias();
+        } else {
+          snapshot = createLocalSnapshot(result);
         }
         setBiasState(snapshot);
       } finally {
         setSaving(false);
       }
     },
-    [user, dayKey, fallbackSaveBiasState, markSchemaStatus, schemaMessage, clearLocalBias]
+    [
+      user,
+      dayKey,
+      fallbackSaveBiasState,
+      markSchemaStatus,
+      schemaMessage,
+      clearLocalBias,
+      createLocalSnapshot,
+    ]
   );
 
   return {


### PR DESCRIPTION
## Summary
- fall back to a locally generated bias snapshot when Supabase responses omit the saved record
- ensure both RPC- and table-based save flows update the UI immediately with the latest selection
- keep the bias cache dependency list in sync with the new snapshot handling

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d91223866483239f83170ac1508c60